### PR TITLE
Add workflow to auto-request review on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-assign.yml
+++ b/.github/workflows/dependabot-auto-assign.yml
@@ -1,0 +1,23 @@
+name: Auto-assign Dependabot PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign PR to brainsaysno
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['brainsaysno']
+            });

--- a/.github/workflows/dependabot-request-review.yml
+++ b/.github/workflows/dependabot-request-review.yml
@@ -1,23 +1,23 @@
-name: Auto-assign Dependabot PRs
+name: Auto-request review for Dependabot PRs
 
 on:
   pull_request:
     types: [opened]
 
 jobs:
-  assign:
+  request-review:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - name: Assign PR to brainsaysno
+      - name: Request review from brainsaysno
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.addAssignees({
+            await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              assignees: ['brainsaysno']
+              pull_number: context.issue.number,
+              reviewers: ['brainsaysno']
             });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically requests a review from @brainsaysno on all Dependabot PRs
- Triggers on pull request open events when the actor is `dependabot[bot]`

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next Dependabot PR to be opened
- [ ] Verify that a review is automatically requested from @brainsaysno

Slack thread: https://tryterac.slack.com/archives/D0AV84HTP7Y/p1777155914.438369

https://claude.ai/code/session_01GxioXcV5bgNkc9yMD33zXp